### PR TITLE
Doesn't exit nix develop shell after pytest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,7 @@
             set -e
             ./scripts/fix.sh
             ./scripts/check.sh
+            set +e
           '';
         };
       }


### PR DESCRIPTION
Tested by running `nix develop` then `pytest`